### PR TITLE
Prevent foreach warning

### DIFF
--- a/mb-rest-api.php
+++ b/mb-rest-api.php
@@ -73,6 +73,10 @@ class MB_Rest_API
 		global $mb_term_meta_boxes;
 		RWMB_Core::get_meta_boxes();
 		$output = array();
+
+		if( !is_array( $mb_term_meta_boxes ) || !$mb_term_meta_boxes instanceof Traversable )
+			return $output;
+
 		foreach ( $mb_term_meta_boxes as $meta_box )
 		{
 			if ( ! in_array( $object['taxonomy'], (array) $meta_box['taxonomies'] ) )


### PR DESCRIPTION
My logs were filling up with PHP warnings:
```
PHP Warning: Invalid argument supplied for foreach() in wp-content/plugins/mb-rest-api/mb-rest-api.php on line 76
```

I'm not sure where the $mb_term_meta_boxes global is supposed to get
set (I couldn't find any references to it outside this file), but in
my setup it was consistently something that `foreach` doesn't like.

This commit just adds a guard to `get_meta_terms` so that it bails early
if the foreach isn't going to like `$mb_term_meta_boxes` - which gets
rid of the warnings.