### PR TITLE
Updates to update_post_meta_rest_api

### DIFF
--- a/mb-rest-api.php
+++ b/mb-rest-api.php
@@ -112,37 +112,37 @@ class MB_Rest_API {
 					if ($field['id'] == $field_name){
 						switch ($field['type']){
 							default: // most types can just be written to post-meta
-                                    // unless they are multiple
-                                // if it's an array passed
-                                if ( is_array($value) ){
-                                    // if multiple, 
-                                    if ($field['multiple']){
-                                        if ($field['clone'] ){
-                                            // clonable, write as csv
-                                            $strval = '';
-                                            foreach ($value as $val) {
-                                                if ($strval != '') $strval = $strval . ',';
-                                                $strval = $strval . $val;
-                                            }
-                                            update_post_meta( $object->ID, $field_name, strip_tags( $strval ) );
-                                        } else {
-                                            // and not clonable, then write as separate post_meta fields
-                                            delete_post_meta($object->ID, $field_name);
-                                            foreach ($value as $val) {
-                                                add_post_meta($object->ID, $field_name, $val);
-                                            }
-                                        }
-                                    } else {
-                                        // something we did not deal with
-                                        error_log( "did not write meta-box field " . var_export( $field ) );
-                                    }
-                                    
+									// unless they are multiple
+								// if it's an array passed
+								if ( is_array($value) ){
+									// if multiple, 
+									if ($field['multiple']){
+										if ($field['clone'] ){
+											// clonable, write as csv
+											$strval = '';
+											foreach ($value as $val) {
+												if ($strval != '') $strval = $strval . ',';
+												$strval = $strval . $val;
+											}
+											update_post_meta( $object->ID, $field_name, strip_tags( $strval ) );
+										} else {
+											// and not clonable, then write as separate post_meta fields
+											delete_post_meta($object->ID, $field_name);
+											foreach ($value as $val) {
+												add_post_meta($object->ID, $field_name, $val);
+											}
+										}
+									} else {
+										// something we did not deal with
+										error_log( "did not write meta-box field " . var_export( $field ) );
+									}
+									
 									$output[ $field_name ] = rwmb_get_value( $field['id'] ); // this just basically returns field.
 								} else {
 									$output[ $field_name ] = update_post_meta( $object->ID, $field_name, strip_tags( $value ) );
 								}
 								break;
-                                
+								
 							case 'taxonomy': // expect { 'slug': 'name' }; ignore other fields
 								$term_taxonomy_ids = wp_set_object_terms( $object->ID, $value['slug'], $field['taxonomy'] );
 								if ( is_wp_error( $term_taxonomy_ids ) ) {

--- a/mb-rest-api.php
+++ b/mb-rest-api.php
@@ -19,7 +19,7 @@ include_once ABSPATH . 'wp-admin/includes/post.php';
 
 /**
  * Meta Box Rest API class
- * @package    Meta Box
+ * @package	Meta Box
  * @subpackage MB Rest API
  */
 class MB_Rest_API {
@@ -28,7 +28,7 @@ class MB_Rest_API {
 	 */
 	public function init() {
 		register_rest_field( $this->get_types(), 'meta_box', array(
-			'get_callback'    => array( $this, 'get_post_meta_rest_api' ),
+			'get_callback'	=> array( $this, 'get_post_meta_rest_api' ),
 			'update_callback' => array( $this, 'update_post_meta_rest_api' )
 		) );
 		register_rest_field( $this->get_types( 'taxonomy' ), 'meta_box', array(
@@ -44,7 +44,7 @@ class MB_Rest_API {
 	 * @return array
 	 */
 	public function get_post_meta_rest_api( $object ) {
-		$output     = array();
+		$output	 = array();
 		$meta_boxes = RWMB_Core::get_meta_boxes();
 		foreach ( $meta_boxes as $meta_box ) {
 			$meta_box = RW_Meta_Box::normalize( $meta_box );
@@ -144,9 +144,12 @@ class MB_Rest_API {
 								break;
 								
 							case 'taxonomy': // expect { 'slug': 'name' }; ignore other fields
-								$term_taxonomy_ids = wp_set_object_terms( $object->ID, $value['slug'], $field['taxonomy'] );
-								if ( is_wp_error( $term_taxonomy_ids ) ) {
-									//what to do?
+								// only allow valid terms
+								if (term_exists( $value['slug'], $field['taxonomy'])){
+									$term_taxonomy_ids = wp_set_object_terms( $object->ID, $value['slug'], $field['taxonomy'] );
+									if (is_wp_error( $term_taxonomy_ids ) ) {
+										//what to do?
+									}
 								}
 								// read the whole field as it is now, as a get would give it
 								$output[ $field_name ] = rwmb_get_value( $field['id'] ); // this just basically returns field.
@@ -187,7 +190,7 @@ class MB_Rest_API {
 				if ( empty( $field['id'] ) ) {
 					continue;
 				}
-				$single                 = $field['clone'] || ! $field['multiple'];
+				$single				 = $field['clone'] || ! $field['multiple'];
 				$field_value = get_term_meta( $object['id'], $field['id'], $single );
 
 				/*

--- a/mb-rest-api.php
+++ b/mb-rest-api.php
@@ -116,8 +116,8 @@ class MB_Rest_API {
 								// if it's an array passed
 								if ( is_array($value) ){
 									// if multiple, 
-									if ($field['multiple']){
-										if ($field['clone'] ){
+									if (isset($field['multiple']) && $field['multiple']){
+										if (isset($field['clone']) && $field['clone']){
 											// clonable, write as csv
 											// **** UNTESTED ****
 											$strval = '';

--- a/mb-rest-api.php
+++ b/mb-rest-api.php
@@ -119,6 +119,7 @@ class MB_Rest_API {
 									if ($field['multiple']){
 										if ($field['clone'] ){
 											// clonable, write as csv
+											// **** UNTESTED ****
 											$strval = '';
 											foreach ($value as $val) {
 												if ($strval != '') $strval = $strval . ',';

--- a/mb-rest-api.php
+++ b/mb-rest-api.php
@@ -156,6 +156,8 @@ class MB_Rest_API {
 								$output[ $field_name ] = rwmb_get_value( $field['id'] ); // this just basically returns field.
 								break;
 						}
+
+						do_action( 'mb_rest_api_set_meta', $object, $field, $output[ $field_name ] );
 						break; // we found the field, so loop to next value
 					}
 				}

--- a/mb-rest-api.php
+++ b/mb-rest-api.php
@@ -102,7 +102,7 @@ class MB_Rest_API {
 			if ( ! in_array( $object->post_type, $meta_box['post_types'] ) ) {
 				continue;
 			}
-			error_log( "using meta-box " . $meta_box['title']  );
+			//error_log( "using meta-box " . $meta_box['title']  );
 
 			
 			//for each value passed in
@@ -232,3 +232,5 @@ class MB_Rest_API {
 
 $mb_rest_api = new MB_Rest_API;
 add_action( 'rest_api_init', array( $mb_rest_api, 'init' ) );
+
+?>


### PR DESCRIPTION
Fixes (?) the fact that WP seems to be giving an object rather than a json string?
Allows for 'taxonomy' and 'multiple' to be updated.
Needs someone who knows meta-box to have a look over.