### PR TITLE
term meta fields save for POST request fix (issue/9)

### DIFF
--- a/class-mb-rest-api.php
+++ b/class-mb-rest-api.php
@@ -95,7 +95,7 @@ class MB_Rest_API {
 	public function update_post_meta( $data, $object ) {
 		if ( is_string( $data ) ) {
 			$data = json_decode( $data, true );
-			if ( JSON_ERROR_NONE === json_last_error() ) {
+			if ( JSON_ERROR_NONE !== json_last_error() ) {
 				return;
 			}
 		}
@@ -142,13 +142,13 @@ class MB_Rest_API {
 	public function update_term_meta( $data, $object ) {
 		if ( is_string( $data ) ) {
 			$data = json_decode( $data, true );
-			if ( JSON_ERROR_NONE === json_last_error() ) {
+			if ( JSON_ERROR_NONE !== json_last_error() ) {
 				return;
 			}
 		}
 
 		foreach ( $data as $field_id => $value ) {
-			$field = rwmb_get_registry( 'field' )->get( $field_id, $object->taxonomy );
+			$field = rwmb_get_registry( 'field' )->get( $field_id, $object->taxonomy, 'term' );
 			$this->update_value( $field, $value, $object->term_id );
 		}
 	}
@@ -184,7 +184,7 @@ class MB_Rest_API {
 	public function update_user_meta( $data, $object ) {
 		if ( is_string( $data ) ) {
 			$data = json_decode( $data, true );
-			if ( JSON_ERROR_NONE === json_last_error() ) {
+			if ( JSON_ERROR_NONE !== json_last_error() ) {
 				return;
 			}
 		}


### PR DESCRIPTION
This is a fix for issue 9 I created on the issues board: https://github.com/wpmetabox/mb-rest-api/issues/9.

Term meta were not getting updated/set because in class-mb-rest-api.php on line 151 you needed to specify the object type (which is 'post' by default):

`$field = rwmb_get_registry( 'field' )->get( $field_id, $object->taxonomy );`

needs to be

`$field = rwmb_get_registry( 'field' )->get( $field_id, $object->taxonomy, 'term' );`

I also updated lines 98, 145, 187 from

`if ( JSON_ERROR_NONE === json_last_error() ) {`

to

`if ( JSON_ERROR_NONE !== json_last_error() ) {`